### PR TITLE
Merge User Preprints changes

### DIFF
--- a/scripts/remove_after_use/fix_unmerged_preprints.py
+++ b/scripts/remove_after_use/fix_unmerged_preprints.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 def main():
 
     # retrieving users that are merged into oblivion
-    merged_users = OSFUser.objects.filter(merged_by__isnull=False)
+    merged_users = OSFUser.objects.filter(merged_by__isnull=False, preprints__isnull=False)
 
     for user in merged_users:
         merged_by = user.merged_by


### PR DESCRIPTION
## Purpose

- restructures _merge_users_preprints to be more parallel to how a user's nodes are merged (except preprints use guardian)
- uses already existing Preprint permissions methods instead of writing groups queries
- adds more tests to catch more of the errors missed
- fixes the script to pull only merged users that still have preprints on them. 

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-100
PR to  https://github.com/CenterForOpenScience/osf.io/pull/8985
