### PR TITLE
[ENG-4510] Add state transition tests for saction tokens

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -866,9 +866,10 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
         # Pass auth=None because the registration initiator may not be
         # an admin on components (component admins had the opportunity
         # to disapprove the registration by this point)
-        registration.set_privacy('public', auth=None, log=False)
-        for child in registration.get_descendants_recursive(primary_only=True):
-            child.set_privacy('public', auth=None, log=False)
+        if not registration.is_embargoed:
+            registration.set_privacy('public', auth=None, log=False)
+            for child in registration.get_descendants_recursive(primary_only=True):
+                child.set_privacy('public', auth=None, log=False)
         # Accounts for system actions where no `User` performs the final approval
         auth = Auth(user) if user else None
         registered_from.add_log(
@@ -882,7 +883,8 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
         )
         for node in registration.root.node_and_primary_descendants():
             self._add_success_logs(node, user)
-            node.update_search()  # update search if public
+            if not registration.is_embargoed:
+                node.update_search()  # update search if public
 
         self.save()
 

--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -52,16 +52,10 @@ def main(dry_run=True):
                 continue
 
             with transaction.atomic():
-                try:
-                    # Call 'accept' trigger directly. This will terminate the embargo
-                    # if the registration is unmoderated or push it into the moderation
-                    # queue if it is part of a moderated registry.
-                    registration_approval.accept()
-                except Exception as err:
-                    logger.error(
-                        'Unexpected error raised when approving registration for '
-                        'registration {}. Continuing...'.format(pending_registration))
-                    logger.exception(err)
+                # Call 'accept' trigger directly. This will terminate the embargo
+                # if the registration is unmoderated or push it into the moderation
+                # queue if it is part of a moderated registry.
+                registration_approval.accept()
 
 
 @celery_app.task(name='scripts.approve_registrations')

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -48,16 +48,10 @@ def main(dry_run=True):
                     continue
 
                 with transaction.atomic():
-                    try:
-                        # Call 'accept' trigger directly. This will terminate the embargo
-                        # if the registration is unmoderated or push it into the moderation
-                        # queue if it is part of a moderated registry.
-                        embargo.accept()
-                    except Exception as err:
-                        logger.error(
-                            'Unexpected error raised when activating embargo for '
-                            'registration {}. Continuing...'.format(parent_registration))
-                        logger.exception(err)
+                    # Call 'accept' trigger directly. This will terminate the embargo
+                    # if the registration is unmoderated or push it into the moderation
+                    # queue if it is part of a moderated registry.
+                    embargo.accept()
 
     active_embargoes = Embargo.objects.filter(state=Embargo.APPROVED)
     for embargo in active_embargoes:
@@ -77,13 +71,7 @@ def main(dry_run=True):
                     continue
 
                 with transaction.atomic():
-                    try:
-                        parent_registration.terminate_embargo()
-                    except Exception as err:
-                        logger.error(
-                            'Unexpected error raised when completing embargo for '
-                            'registration {}. Continuing...'.format(parent_registration))
-                        logger.exception(err)
+                    parent_registration.terminate_embargo()
 
 
 def should_be_embargoed(embargo):

--- a/scripts/retract_registrations.py
+++ b/scripts/retract_registrations.py
@@ -27,12 +27,7 @@ def main(dry_run=True):
         if should_be_retracted(retraction):
             if dry_run:
                 logger.warn('Dry run mode')
-            try:
                 parent_registration = retraction.registrations.get()
-            except Exception as err:
-                logger.exception('Could not find registration associated with retraction {}'.format(retraction))
-                logger.error('Skipping...'.format(retraction))
-                continue
 
             logger.warn(
                 'Retraction {0} approved. Retracting registration {1}'
@@ -40,13 +35,7 @@ def main(dry_run=True):
             )
             if not dry_run:
                 with transaction.atomic():
-                    try:
-                        retraction.accept()
-                    except Exception as err:
-                        logger.error(
-                            'Unexpected error raised when retracting '
-                            'registration {}. Continuing...'.format(parent_registration))
-                        logger.exception(err)
+                    retraction.accept()
 
 
 def should_be_retracted(retraction):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -2,6 +2,7 @@ import jwt
 from rest_framework import status as http_status
 
 import mock
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from nose.tools import *  # noqa
 
@@ -12,13 +13,25 @@ from tests.utils import mock_auth
 from framework.exceptions import HTTPError
 
 from website import settings
-from osf.models import AbstractNode, Embargo, RegistrationApproval, Retraction, Sanction
+from osf.models import (
+    AbstractNode,
+    Embargo,
+    RegistrationApproval,
+    Retraction,
+    Sanction,
+    Registration,
+    NodeLog
+)
 from osf.utils.tokens import decode, encode, TokenHandler
 from osf.exceptions import TokenHandlerNotFound
+from scripts.embargo_registrations import main as embargo_registrations
+from scripts.approve_registrations import main as approve_registrations
+from django.utils import timezone
 
 NO_SANCTION_MSG = 'There is no {0} associated with this token.'
 APPROVED_MSG = 'This registration is not pending {0}.'
 REJECTED_MSG = 'This registration {0} has been rejected.'
+
 
 class TestTokenHandler(OsfTestCase):
 
@@ -71,50 +84,55 @@ class TestTokenHandler(OsfTestCase):
             )
         )
 
-class SanctionTokenHandlerBase(OsfTestCase):
+
+class SanctionTokenHandlerBase:
 
     kind = None
-    Model = None
-    Factory = None
+    model = None
+    factory = None
 
     def setUp(self, *args, **kwargs):
-        OsfTestCase.setUp(self, *args, **kwargs)
-        if not self.kind:
-            return
-        self.sanction = self.Factory()
-        self.reg = AbstractNode.objects.get(Q(**{self.Model.SHORT_NAME: self.sanction}))
+        super().setUp(*args, **kwargs)
+        self.sanction = self.factory()
+        self.reg = AbstractNode.objects.get(Q(**{self.model.SHORT_NAME: self.sanction}))
         self.user = self.reg.creator
 
     def test_sanction_handler(self):
-        if not self.kind:
-            return
         approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
+
         with mock_auth(self.user):
-            with mock.patch('osf.utils.tokens.handlers.{0}_handler'.format(self.kind)) as mock_handler:
+            with mock.patch(f'osf.utils.tokens.handlers.{self.kind}_handler') as mock_handler:
                 handler.to_response()
                 mock_handler.assert_called_with('approve', self.reg, self.reg.registered_from)
 
+        self.sanction.reload()
+        assert self.sanction.state == Sanction.APPROVED
+        if self.reg.registration_approval:
+            assert self.reg.registration_approval.state == RegistrationApproval.APPROVED
+
     def test_sanction_handler_no_sanction(self):
-        if not self.kind:
-            return
+        assert self.sanction.state == Sanction.UNAPPROVED
         approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        self.Model.delete(self.sanction)
+        self.model.delete(self.sanction)
         with mock_auth(self.user):
             try:
                 handler.to_response()
             except HTTPError as e:
                 assert_equal(e.code, http_status.HTTP_400_BAD_REQUEST)
-                assert_equal(e.data['message_long'], NO_SANCTION_MSG.format(self.Model.DISPLAY_NAME))
+                assert_equal(e.data['message_long'], NO_SANCTION_MSG.format(self.model.DISPLAY_NAME))
+
+        try:
+            self.sanction.reload()
+        except ObjectDoesNotExist:
+            # it should be deleted
+            pass
 
     def test_sanction_handler_sanction_approved(self):
-        if not self.kind:
-            return
+        assert self.sanction.state == Sanction.UNAPPROVED
         approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        self.sanction.state = Sanction.APPROVED
-        self.sanction.save()
         with mock_auth(self.user):
             try:
                 handler.to_response()
@@ -122,13 +140,16 @@ class SanctionTokenHandlerBase(OsfTestCase):
                 assert_equal(e.code, http_status.HTTP_400_BAD_REQUEST if self.kind in ['embargo', 'registration_approval'] else http_status.HTTP_410_GONE)
                 assert_equal(e.data['message_long'], APPROVED_MSG.format(self.sanction.DISPLAY_NAME))
 
+        self.sanction.reload()
+        assert self.sanction.state == Sanction.APPROVED
+        if self.reg.registration_approval:
+            assert self.reg.registration_approval.state == RegistrationApproval.APPROVED
+
     def test_sanction_handler_sanction_rejected(self):
-        if not self.kind:
-            return
-        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
+        assert self.sanction.state == Sanction.UNAPPROVED
+        approval_token = self.sanction.approval_state[self.user._id]['rejection_token']
         handler = TokenHandler.from_string(approval_token)
-        self.sanction.state = Sanction.REJECTED
-        self.sanction.save()
+
         with mock_auth(self.user):
             try:
                 handler.to_response()
@@ -136,20 +157,28 @@ class SanctionTokenHandlerBase(OsfTestCase):
                 assert_equal(e.code, http_status.HTTP_410_GONE if self.kind in ['embargo', 'registration_approval'] else http_status.HTTP_400_BAD_REQUEST)
                 assert_equal(e.data['message_long'], REJECTED_MSG.format(self.sanction.DISPLAY_NAME))
 
-class TestEmbargoTokenHandler(SanctionTokenHandlerBase):
+        self.sanction.reload()
+        assert self.sanction.state == Sanction.REJECTED
+        if self.reg.registration_approval:
+            assert self.reg.registration_approval.state == self.model.REJECTED
+
+
+class TestEmbargoTokenHandler(SanctionTokenHandlerBase, OsfTestCase):
 
     kind = 'embargo'
-    Model = Embargo
-    Factory = factories.EmbargoFactory
+    model = Embargo
+    factory = factories.EmbargoFactory
 
-class TestRegistrationApprovalTokenHandler(SanctionTokenHandlerBase):
+
+class TestRegistrationApprovalTokenHandler(SanctionTokenHandlerBase, OsfTestCase):
 
     kind = 'registration_approval'
-    Model = RegistrationApproval
-    Factory = factories.RegistrationApprovalFactory
+    model = RegistrationApproval
+    factory = factories.RegistrationApprovalFactory
 
-class TestRetractionTokenHandler(SanctionTokenHandlerBase):
+
+class TestRetractionTokenHandler(SanctionTokenHandlerBase, OsfTestCase):
 
     kind = 'retraction'
-    Model = Retraction
-    Factory = factories.RetractionFactory
+    model = Retraction
+    factory = factories.RetractionFactory

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -182,3 +182,48 @@ class TestRetractionTokenHandler(SanctionTokenHandlerBase, OsfTestCase):
     kind = 'retraction'
     model = Retraction
     factory = factories.RetractionFactory
+
+
+class TestEmbargoModerationWorkflow(OsfTestCase):
+
+    def test_embargo_workflow(self):
+        embargo = factories.EmbargoFactory(end_date=timezone.now())
+        registration = Registration.objects.get(Q(**{'embargo': embargo}))
+        assert not registration.is_public
+        registration_approval = factories.RegistrationApprovalFactory(
+            target_item=registration,
+            initiated_by=registration.creator
+        )
+        assert not registration.is_embargoed
+        assert registration.registration_approval.state == RegistrationApproval.UNAPPROVED
+        assert registration.embargo.state == Embargo.UNAPPROVED
+
+        approval_token = embargo.approval_state[registration.creator._id]['approval_token']
+        handler = TokenHandler.from_string(approval_token)
+
+        with mock_auth(registration.creator):
+            with mock.patch(f'osf.utils.tokens.handlers.embargo_handler') as mock_handler:
+                handler.to_response()
+                mock_handler.assert_called_with('approve', registration, registration.registered_from)
+
+        registration.reload()
+        assert registration.is_embargoed
+        assert registration.registration_approval.state == RegistrationApproval.UNAPPROVED
+        registration_approval.initiation_date = timezone.now() - settings.REGISTRATION_APPROVAL_TIME
+        registration_approval.save()
+        registration.save()
+        approve_registrations(dry_run=False)
+
+        registration.reload()
+        assert registration.registration_approval.state == RegistrationApproval.APPROVED
+        assert not registration.is_public
+
+        embargo_registrations(dry_run=False)
+
+        registration.reload()
+        assert registration.embargo.state == Embargo.COMPLETED
+        assert registration.is_public
+        # Assert False here to see the other errors in state transition
+        assert registration.registration_approval.state == RegistrationApproval.APPROVED
+
+        assert registration.registered_from.logs.filter(action=NodeLog.REGISTRATION_APPROVAL_APPROVED)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -223,7 +223,7 @@ class TestEmbargoModerationWorkflow(OsfTestCase):
         registration.reload()
         assert registration.embargo.state == Embargo.COMPLETED
         assert registration.is_public
-        # Assert False here to see the other errors in state transition
-        assert registration.registration_approval.state == RegistrationApproval.APPROVED
 
+        # Due to bug must check for state changed and log entry
+        assert registration.registration_approval.state == RegistrationApproval.APPROVED
         assert registration.registered_from.logs.filter(action=NodeLog.REGISTRATION_APPROVAL_APPROVED)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Help debug registration moderation transition state bugs by improving tests.

## Changes

- Fixes approval token tests to check for sanction state
- Fixes test class composition so the abstract base class isn't run.
- Fixes capitalization and minor code errors

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

It looks like an error in the sanction logic wasn't getting caught because it was inside an generic exception clause. The error stemmed from there being no real condition for the user auth not being passed during an embargoed registration.

```
 =================================== FAILURES ===================================
_____________ TestEmbargoModerationWorkflow.test_embargo_workflow ______________
tests/test_tokens.py:216: in test_embargo_workflow
    assert registration_approval.state == RegistrationApproval.APPROVED
E   AssertionError: assert 'unapproved' == 'approved'
E     - unapproved
E     ? --
E     + approved
------------------------------ Captured log call -------------------------------
WARNING  scripts.approve_registrations:approve_registrations.py:43 RegistrationApproval 645a50a3d99d81199c273e85 automatically approved by system. Making registration fnm4c public.
ERROR    scripts.approve_registrations:approve_registrations.py:63 Unexpected error raised when approving registration for registration Registration object (909). Continuing...
ERROR    scripts.approve_registrations:approve_registrations.py:64 'NoneType' object has no attribute 'user'
Traceback (most recent call last):
  File "/home/runner/work/osf.io/osf.io/scripts/approve_registrations.py", line 59, in main
    registration_approval.accept()
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 390, in trigger
    return self.machine._process(func)
  File "/home/runner/work/osf.io/osf.io/osf/utils/machines.py", line 371, in _process
    super()._process(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 1127, in _process
    self._transition_queue[0]()
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 408, in _trigger
    return self._process(event_data)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 417, in _process
    if trans.execute(event_data):
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 271, in execute
    event_data.machine.callbacks(itertools.chain(self.after, event_data.machine.after_state_change), event_data)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 1049, in callbacks
    self.callback(func, event_data)
  File "/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/transitions/core.py", line 1068, in callback
    func(event_data)
  File "/home/runner/work/osf.io/osf.io/osf/models/sanctions.py", line 869, in _on_complete
    registration.set_privacy('public', auth=None, log=False)
  File "/home/runner/work/osf.io/osf.io/osf/models/node.py", line 1235, in set_privacy
    self.request_embargo_termination(auth.user)
AttributeError: 'NoneType' object has no attribute 'user'
=============================== warnings summary ===============================
```
https://github.com/Johnetordoff/osf.io/pull/182/commits/95a95bcc9d77ec1523543f1dbf025bc552f5f4a7

`registration.set_privacy('public', auth=None, log=False)` is the key line here, this will always cause an embergoed registration to fail.

As you can see here, the generic exception handling is suppressing the message, but the tests still pass because the error happens `after` the state change in the state machine. It's also unclear what the atomic transaction context is supposed to do here as it's being iterated on, meaning we are making many small transactions.

But to be clear the main problem is that generic exception handling is suppressing the bug, so only certain parts of the state change happens, the stuff before it hits, `self.request_embargo_termination(auth.user)` in `set_privacy`.

As you can see in the RegistrationApprovals `_on_complete`:

```
    def _on_complete(self, event_data):
        user = event_data.kwargs.get('user')
        if user is None and event_data.args:
            user = event_data.args[0]
        NodeLog = apps.get_model('osf.NodeLog')

        registration = self._get_registration()
        if registration.is_spammy:
            raise NodeStateError('Cannot approve a spammy registration')

        super()._on_complete(event_data)
        self.save()
        registered_from = registration.registered_from
        # Pass auth=None because the registration initiator may not be
        # an admin on components (component admins had the opportunity
        # to disapprove the registration by this point)
        registration.set_privacy('public', auth=None, log=False)
        for child in registration.get_descendants_recursive(primary_only=True):
            child.set_privacy('public', auth=None, log=False)
        # Accounts for system actions where no `User` performs the final approval
        auth = Auth(user) if user else None
        registered_from.add_log(
            action=NodeLog.REGISTRATION_APPROVAL_APPROVED,
            params={
                'node': registered_from._id,
                'registration': registration._id,
                'registration_approval_id': self._id,
            },
            auth=auth,
        )
        for node in registration.root.node_and_primary_descendants():
            self._add_success_logs(node, user)
            node.update_search()  # update search if public

        self.save()
```

if it fails in `set_privacy` the log action  `REGISTRATION_APPROVAL_APPROVED` will never be created. So I just skipped over the `set_privacy` step for embargoed registrations.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4510