### PR TITLE
S3 improvement prototype

### DIFF
--- a/addons/s3/models.py
+++ b/addons/s3/models.py
@@ -8,11 +8,18 @@ from osf.models.files import File, Folder, BaseFileNode
 from addons.base import exceptions
 from addons.s3.provider import S3Provider
 from addons.s3.serializer import S3Serializer
-from addons.s3.settings import (BUCKET_LOCATIONS,
-                                        ENCRYPT_UPLOADS_DEFAULT)
-from addons.s3.utils import (bucket_exists,
-                                     get_bucket_location_or_error,
-                                     get_bucket_names)
+from addons.s3.settings import (
+    BUCKET_LOCATIONS,
+    ENCRYPT_UPLOADS_DEFAULT
+)
+from addons.s3.utils import (
+    bucket_exists,
+    get_bucket_location_or_error,
+    get_bucket_names,
+    get_bucket_prefixes
+)
+from website.util import api_v2_url
+
 
 class S3FileNode(BaseFileNode):
     _provider = 's3'
@@ -55,8 +62,8 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def display_name(self):
         return u'{0}: {1}'.format(self.config.full_name, self.folder_id)
 
-    def set_folder(self, folder_id, auth):
-        if not bucket_exists(self.external_account.oauth_key, self.external_account.oauth_secret, folder_id):
+    def set_folder(self, folder_id, auth, bucket_name=None):
+        if not bucket_exists(self.external_account.oauth_key, self.external_account.oauth_secret, bucket_name):
             error_message = ('We are having trouble connecting to that bucket. '
                              'Try a different one.')
             raise exceptions.InvalidFolderError(error_message)
@@ -66,7 +73,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         bucket_location = get_bucket_location_or_error(
             self.external_account.oauth_key,
             self.external_account.oauth_secret,
-            folder_id
+            bucket_name
         )
         try:
             bucket_location = BUCKET_LOCATIONS[bucket_location]
@@ -78,29 +85,45 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.folder_name = '{} ({})'.format(folder_id, bucket_location)
         self.save()
 
-        self.nodelogger.log(action='bucket_linked', extra={'bucket': str(folder_id)}, save=True)
+        self.nodelogger.log(action='bucket_linked', extra={'bucket': bucket_name, 'path': self.folder_id}, save=True)
 
     def get_folders(self, **kwargs):
-        # This really gets only buckets, not subfolders,
-        # as that's all we want to be linkable on a node.
-        try:
-            buckets = get_bucket_names(self)
-        except Exception:
-            raise exceptions.InvalidAuthError()
+        """
+        Our S3 implementation allows for folder_id to be a bucket's root, or a subfolder in that bucket.
+        """
+        path = kwargs.get('path')
+        bucket_name = kwargs.get('bucket_name')
 
-        return [
-            {
+        # This is the root, so list all buckets.
+        if not bucket_name:
+            buckets = get_bucket_names(self)
+
+            return [{
                 'addon': 's3',
                 'kind': 'folder',
                 'id': bucket,
                 'name': bucket,
-                'path': bucket,
+                'bucket_name': bucket,
+                'path': '/',
                 'urls': {
-                    'folders': ''
+                    'folders': api_v2_url(
+                        f'nodes/{self.owner._id}/addons/s3/folders/',
+                        params={
+                            'id': bucket,
+                            'bucket_name': bucket,
+                        }
+                    ),
                 }
-            }
-            for bucket in buckets
-        ]
+            } for bucket in buckets]
+        # This is for a directory for a specific bucket, folders (Prefixes), but not files (Keys) returned, because
+        # these we can only set folders as our base folder_id
+        else:
+            return get_bucket_prefixes(
+                self.external_account.oauth_key,
+                self.external_account.oauth_secret,
+                prefix=path,
+                bucket_name=bucket_name
+            )
 
     @property
     def complete(self):
@@ -135,10 +158,16 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         }
 
     def serialize_waterbutler_settings(self):
+        """
+        We use the folder id to hold the bucket location
+        """
         if not self.folder_id:
             raise exceptions.AddonError('Cannot serialize settings for S3 addon')
+
+        bucket_name, _, folder_id = self.folder_id.partition('/')
         return {
-            'bucket': self.folder_id,
+            'bucket': bucket_name,  # fool wb
+            'id': folder_id,
             'encrypt_uploads': self.encrypt_uploads
         }
 

--- a/addons/s3/static/s3NodeConfig.js
+++ b/addons/s3/static/s3NodeConfig.js
@@ -28,7 +28,7 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
             {   // TreeBeard Options
                 columnTitles: function() {
                     return [{
-                        title: 'Buckets',
+                        title: 'Buckets/Folders',
                         width: '75%',
                         sort: false
                     }, {
@@ -36,12 +36,6 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
                         width: '25%',
                         sort: false
                     }];
-                },
-                resolveToggle: function(item) {
-                    return '';
-                },
-                resolveIcon: function(item) {
-                    return m('i.fa.fa-folder-o', ' ');
                 },
             },
             tbOpts

--- a/addons/s3/tests/test_model.py
+++ b/addons/s3/tests/test_model.py
@@ -38,6 +38,14 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     NodeSettingsClass = NodeSettings
     UserSettingsFactory = S3UserSettingsFactory
 
+    def _node_settings_class_kwargs(self, node, user_settings):
+        return {
+            'user_settings': self.user_settings,
+            'folder_id': 'bucket_name/path_goes_here/with_folder_id',
+            'owner': self.node
+        }
+
+
     def test_registration_settings(self):
         registration = ProjectFactory()
         clone, message = self.node_settings.after_register(
@@ -96,6 +104,9 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
-        expected = {'bucket': self.node_settings.folder_id,
-                    'encrypt_uploads': self.node_settings.encrypt_uploads}
+        expected = {
+            'bucket': 'bucket_name',
+            'encrypt_uploads': self.node_settings.encrypt_uploads,
+            'id': 'path_goes_here/with_folder_id'
+        }
         assert_equal(settings, expected)

--- a/addons/s3/tests/test_model.py
+++ b/addons/s3/tests/test_model.py
@@ -41,7 +41,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def _node_settings_class_kwargs(self, node, user_settings):
         return {
             'user_settings': self.user_settings,
-            'folder_id': 'bucket_name/path_goes_here/with_folder_id',
+            'folder_id': 'bucket_name:/path_goes_here/with_folder_id',
             'owner': self.node
         }
 
@@ -107,6 +107,6 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         expected = {
             'bucket': 'bucket_name',
             'encrypt_uploads': self.node_settings.encrypt_uploads,
-            'id': 'path_goes_here/with_folder_id'
+            'id': 'bucket_name:/path_goes_here/with_folder_id'
         }
         assert_equal(settings, expected)

--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -18,7 +18,7 @@ def connect_s3(access_key=None, secret_key=None, node_settings=None):
     if node_settings is not None:
         if node_settings.external_account is not None:
             access_key, secret_key = node_settings.external_account.oauth_key, node_settings.external_account.oauth_secret
-    connection = S3Connection(access_key, secret_key, calling_format=OrdinaryCallingFormat())
+    connection = S3Connection(access_key, secret_key)
     return connection
 
 

--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -122,3 +122,24 @@ def get_bucket_location_or_error(access_key, secret_key, bucket_name):
         return connect_s3(access_key, secret_key).get_bucket(bucket_name, validate=False).get_location()
     except exception.S3ResponseError:
         raise InvalidFolderError()
+
+
+def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
+    bucket = connect_s3(access_key, secret_key).get_bucket(bucket_name)
+
+    folders = []
+    for key in bucket.list(delimiter='/', prefix=prefix):
+        if key.name.endswith('/') and key.name != prefix:
+            folders.append(
+                {
+                    'path': key.name,
+                    'id': f'{bucket_name}/{key.name}',
+                    'folder_id': key.name,
+                    'kind': 'folder',
+                    'bucket_name': bucket_name,
+                    'name': key.name.split('/')[-2],
+                    'addon': 's3',
+                }
+            )
+
+    return folders

--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -124,7 +124,7 @@ def get_bucket_location_or_error(access_key, secret_key, bucket_name):
         raise InvalidFolderError()
 
 
-def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
+def get_bucket_prefixes(access_key, secret_key, prefix, bucket_name):
     bucket = connect_s3(access_key, secret_key).get_bucket(bucket_name)
 
     folders = []
@@ -133,7 +133,7 @@ def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
             folders.append(
                 {
                     'path': key.name,
-                    'id': f'{bucket_name}/{key.name}',
+                    'id': f'{bucket_name}:/{key.name}',
                     'folder_id': key.name,
                     'kind': 'folder',
                     'bucket_name': bucket_name,

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -41,12 +41,7 @@ s3_get_config = generic_views.get_config(
 
 def _set_folder(node_addon, folder, auth):
     folder_id = folder['id']
-    if folder['path'] == '/':
-        node_addon.set_folder(folder_id, auth=auth, bucket_name=folder_id)
-    else:
-        bucket_name = folder_id.split('/')[0]
-        node_addon.set_folder(folder_id, auth=auth, bucket_name=bucket_name)
-
+    node_addon.set_folder(folder_id, auth=auth)
     node_addon.save()
 
 s3_set_config = generic_views.set_config(
@@ -62,9 +57,8 @@ def s3_folder_list(node_addon, **kwargs):
     """ Returns all the subsequent folders under the folder id passed.
     """
     path = request.args.get('path', '')
-    id = request.args.get('id', '')
-    bucket_name = request.args.get('bucket_name', '')
-    return node_addon.get_folders(path=path, folder_id=id, bucket_name=bucket_name)
+    folder_id = request.args.get('id', '')
+    return node_addon.get_folders(path=path, folder_id=folder_id)
 
 @must_be_logged_in
 def s3_add_user_account(auth, **kwargs):

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -41,7 +41,12 @@ s3_get_config = generic_views.get_config(
 
 def _set_folder(node_addon, folder, auth):
     folder_id = folder['id']
-    node_addon.set_folder(folder_id, auth=auth)
+    if folder['path'] == '/':
+        node_addon.set_folder(folder_id, auth=auth, bucket_name=folder_id)
+    else:
+        bucket_name = folder_id.split('/')[0]
+        node_addon.set_folder(folder_id, auth=auth, bucket_name=bucket_name)
+
     node_addon.save()
 
 s3_set_config = generic_views.set_config(
@@ -56,7 +61,10 @@ s3_set_config = generic_views.set_config(
 def s3_folder_list(node_addon, **kwargs):
     """ Returns all the subsequent folders under the folder id passed.
     """
-    return node_addon.get_folders()
+    path = request.args.get('path', '')
+    id = request.args.get('id', '')
+    bucket_name = request.args.get('bucket_name', '')
+    return node_addon.get_folders(path=path, folder_id=id, bucket_name=bucket_name)
 
 @must_be_logged_in
 def s3_add_user_account(auth, **kwargs):

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -12,7 +12,7 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
     id = ser.CharField(read_only=True)
     kind = ser.CharField(default='folder', read_only=True)
     name = ser.CharField(read_only=True)
-    folder_id = ser.SerializerMethodField(read_only=True)
+    folder_id = ser.CharField(source='id', read_only=True)
     path = ser.CharField(read_only=True)
     provider = ser.CharField(source='addon', read_only=True)
 
@@ -44,12 +44,6 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
             kwargs=self.context['request'].parser_context['kwargs'],
         )
 
-    def get_folder_id(self, obj):
-        if obj['addon'] == 's3':
-            # Addons with special top level directories such as a bucket with subfolders get a `:` delineator.
-            return f'{obj["bucket_name"]}:{obj["path"]}'
-        else:
-            return obj['id']
 
 class AddonSerializer(JSONAPISerializer):
     filterable_fields = frozenset([

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -22,18 +22,23 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
     })
 
     def get_absolute_url(self, obj):
-        if obj['addon'] in ('s3', 'figshare', 'github', 'mendeley'):
+        if obj['addon'] in ('figshare', 'github', 'mendeley'):
             # These addons don't currently support linking anything other
             # than top-level objects.
             return
 
+        query_kwargs = {
+            'path': obj['path'],
+            'id': obj['id'],
+        }
+
+        if obj['addon'] == 's3' and obj['kind'] == 'folder':  # Send S3 bucket name
+            query_kwargs['bucket_name'] = obj.get('bucket_name', '')
+
         return absolute_reverse(
             'nodes:node-addon-folders',
             kwargs=self.context['request'].parser_context['kwargs'],
-            query_kwargs={
-                'path': obj['path'],
-                'id': obj['id'],
-            },
+            query_kwargs=query_kwargs,
         )
 
     def get_root_folder(self, obj):

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -44,7 +44,6 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
             kwargs=self.context['request'].parser_context['kwargs'],
         )
 
-
 class AddonSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'categories',

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -61,7 +61,7 @@ INSTITUTION_SELECTIVE_SSO_MAP = {
         'criteria_action': SsoFilterCriteriaAction.EQUALS_TO.value,
         'criteria_value': 'http://directory.manchester.ac.uk/epe/3rdparty/osf',
     },
-    'yalelaw': {
+    'yls': {
         'criteria_action': SsoFilterCriteriaAction.IN.value,
         'criteria_value': ['Yes', 'yes', 'y'],
     },

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1454,14 +1454,13 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
 
         path = self.request.query_params.get('path')
         folder_id = self.request.query_params.get('id')
-        bucket_name = self.request.query_params.get('bucket_name')
 
         if not hasattr(node_addon, 'get_folders'):
             raise EndpointNotImplementedError('Endpoint not yet implemented for this addon')
 
         #  Convert v1 errors to v2 as much as possible.
         try:
-            return node_addon.get_folders(path=path, folder_id=folder_id, bucket_name=bucket_name)
+            return node_addon.get_folders(path=path, folder_id=folder_id)
         except InvalidAuthError:
             raise NotAuthenticated('This add-on could not be authenticated.')
         except HTTPError as exc:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1454,13 +1454,14 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
 
         path = self.request.query_params.get('path')
         folder_id = self.request.query_params.get('id')
+        bucket_name = self.request.query_params.get('bucket_name')
 
         if not hasattr(node_addon, 'get_folders'):
             raise EndpointNotImplementedError('Endpoint not yet implemented for this addon')
 
         #  Convert v1 errors to v2 as much as possible.
         try:
-            return node_addon.get_folders(path=path, folder_id=folder_id)
+            return node_addon.get_folders(path=path, folder_id=folder_id, bucket_name=bucket_name)
         except InvalidAuthError:
             raise NotAuthenticated('This add-on could not be authenticated.')
         except HTTPError as exc:

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -120,7 +120,7 @@ def institution_selective_type_1():
 @pytest.fixture()
 def institution_selective_type_2():
     institution = InstitutionFactory()
-    institution._id = 'yalelaw'
+    institution._id = 'yls'
     institution.save()
     return institution
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1013,7 +1013,7 @@ class TestNodeS3Addon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
     def _mock_folder_result(self):
         return {
             'name': 'a.bucket',
-            'path': 'a.bucket',
+            'path': '/',
             'id': 'a.bucket'
         }
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -805,7 +805,7 @@ class TestNodeZoteroAddon(
                 'fileEditing': 'members',
                 'libraryEditing': 'members',
                 'type': 'Private',
-                'id': 18497322,
+                'id': '18497322',
                 'name': 'Group Library I'
             },
             'version': 1,

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1014,7 +1014,7 @@ class TestNodeS3Addon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
         return {
             'name': 'a.bucket',
             'path': '/',
-            'id': 'a.bucket'
+            'id': 'a.bucket:/'
         }
 
     @mock.patch('addons.s3.models.get_bucket_names')

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -212,7 +212,7 @@ INSTITUTIONS = {
                 'name': 'Carnegie Mellon University',
                 'description': 'A Project Management Tool for the CMU Community: <a href="https://l'
                                'ibrary.cmu.edu/OSF">Get Help at CMU</a> | <a href="https://cos.io/o'
-                               'ur-products/osf/">About OSF</a> | <a href="https://osf.io/support/"'
+                               'ur-products/osf/">About OSF</a> | <a href="https://help.osf.io/"'
                                '>OSF Support</a> | <a href="https://library.cmu.edu/OSF/terms-of-us'
                                'e">Terms of Use</a>',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://login.cmu.edu/idp/shibboleth')),
@@ -1151,7 +1151,7 @@ INSTITUTIONS = {
                 'name': 'Carnegie Mellon University [Test]',
                 'description': 'A Project Management Tool for the CMU Community: <a href="https://l'
                                'ibrary.cmu.edu/OSF">Get Help at CMU</a> | <a href="https://cos.io/o'
-                               'ur-products/osf/">About OSF</a> | <a href="https://osf.io/support/"'
+                               'ur-products/osf/">About OSF</a> | <a href="https://help.osf.io/"'
                                '>OSF Support</a> | <a href="https://library.cmu.edu/OSF/terms-of-us'
                                'e">Terms of Use</a>',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://login.cmu.edu/idp/shibboleth')),

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -12,7 +12,6 @@ routes = [
     '/quickfiles/',
     '/<uid>/quickfiles/',
     '/institutions/',
-    '/support/',
 ]
 
 def use_ember_app(**kwargs):

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -288,7 +288,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='HOME', service_url=domain, service_support_url='/support/')}
+    ${nav_helper.nav(service_name='HOME', service_url=domain, service_support_url='https://help.osf.io/')}
 </%def>
 
 <%def name="title()">

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -63,7 +63,7 @@
 
                 <ul class="dropdown-menu auth-dropdown" role="menu">
                     <li><a data-bind="click: trackClick.bind($data, 'MyProfile')" href="${domain}profile/"><i class="fa fa-user fa-lg p-r-xs"></i> My Profile</a></li>
-                    <li><a data-bind="click: trackClick.bind($data, 'Support')" href="${domain}support/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> OSF Support</a></li>
+                    <li><a data-bind="click: trackClick.bind($data, 'Support')" href="https://help.osf.io/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> OSF Support</a></li>
                     <li><a data-bind="click: trackClick.bind($data, 'Settings')" href="${web_url_for('user_profile')}"><i class="fa fa-cog fa-lg p-r-xs"></i> Settings</a></li>
                     <li><a data-bind="click: trackClick.bind($data, 'Logout')" href="${web_url_for('auth_logout')}"><i class="fa fa-sign-out fa-lg p-r-xs"></i> Log out</a></li>
                 </ul>


### PR DESCRIPTION
## Purpose

A system to allow a holder of S3 IAM credentials to link a CommonPrefix of their bucket to a project. This will allow project and their registrations to contain only a subset of the items inside a bucket.

## Changes

- A bucket's root level path is now `/` instead of that buckets name.
- S3 special casing replaced in the NodeAddonFolderSerializer, S3 now passes a `bucket_name` query param to it's child buckets.
- Similar special casing for `bucket_name` in NodeAddonFolderList

## QA Notes

Hypothetical behavior
![S3-improvement](https://github.com/Johnetordoff/osf.io/assets/9688518/d7bd7ef2-cf69-4f52-9226-23525a517281)


Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

Waterbutler-side fix
https://github.com/CenterForOpenScience/waterbutler/pull/403

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
